### PR TITLE
Fix warning from C99 compilers about void functions

### DIFF
--- a/esp32-s2-kaluga-1/components/cam/cam.c
+++ b/esp32-s2-kaluga-1/components/cam/cam.c
@@ -461,7 +461,7 @@ void cam_dma_config(const cam_config_t *config)
     I2S0.rx_eof_num = cam_obj->half_buffer_size; /*!< Ping-pong operation */
 }
 
-esp_err_t cam_deinit()
+esp_err_t cam_deinit(void)
 {
     if (!cam_obj) {
         return ESP_FAIL;

--- a/esp32-s2-kaluga-1/components/es8311/es8311.c
+++ b/esp32-s2-kaluga-1/components/es8311/es8311.c
@@ -472,7 +472,7 @@ esp_err_t es8311_init(int sample_fre)
     return ESP_OK;
 }
 
-esp_err_t es8311_deinit()
+esp_err_t es8311_deinit(void)
 {
     es8311_pa_power(false);
     return ESP_OK;
@@ -540,7 +540,7 @@ int es8311_set_mic_gain(es8311_mic_gain_t gain_db)
     return res;
 }
 
-void es8311_read_all()
+void es8311_read_all(void)
 {
     for (int i = 0; i < 0x4A; i++) {
         uint8_t reg = es8311_read_reg(i);

--- a/esp32-s2-kaluga-1/components/i2c_bus/i2c_bus.c
+++ b/esp32-s2-kaluga-1/components/i2c_bus/i2c_bus.c
@@ -80,7 +80,7 @@ esp_err_t i2c_bus_read_data(uint8_t slave_addr, uint8_t *pdata, int size)
     return res ? ESP_FAIL: ESP_OK;
 }
 
-esp_err_t i2c_bus_init()
+esp_err_t i2c_bus_init(void)
 {
     int res;
     int i2c_master_port = I2C_NUM_0;

--- a/esp32-s2-kaluga-1/components/i2c_bus/include/i2c_bus.h
+++ b/esp32-s2-kaluga-1/components/i2c_bus/include/i2c_bus.h
@@ -27,7 +27,7 @@ esp_err_t i2c_bus_read_reg(uint8_t slave_addr, uint8_t reg_addr, uint8_t *pdata)
 
 esp_err_t i2c_bus_read_data(uint8_t slave_addr, uint8_t *pdata, int size);
 
-esp_err_t i2c_bus_init();
+esp_err_t i2c_bus_init(void);
 
 #ifdef __cplusplus
 }

--- a/esp32-s2-kaluga-1/components/lcd/include/lcd.h
+++ b/esp32-s2-kaluga-1/components/lcd/include/lcd.h
@@ -36,7 +36,7 @@ typedef struct {
 /**
  * @brief  lcd restart
  */
-void lcd_rst();
+void lcd_rst(void);
 
 /**
  * @brief write data in LCD

--- a/esp32-s2-kaluga-1/components/lcd/lcd.c
+++ b/esp32-s2-kaluga-1/components/lcd/lcd.c
@@ -173,7 +173,7 @@ void lcd_write_data(uint8_t *data, size_t len)
     spi_write_data(data, len);
 }
 
-void lcd_rst()
+void lcd_rst(void)
 {
     lcd_set_rst(0);
     lcd_delay_ms(100);

--- a/esp32-s2-kaluga-1/components/sensors/include/sccb.h
+++ b/esp32-s2-kaluga-1/components/sensors/include/sccb.h
@@ -30,7 +30,7 @@ int SCCB_Init(int pin_sda, int pin_scl);
  * @return sensor address (slv_addr) ov2640: 0x30
  *                                   ov3660: 0x3c
  */
-uint8_t SCCB_Probe();
+uint8_t SCCB_Probe(void);
 
 /**
  * @brief Write the register

--- a/esp32-s2-kaluga-1/components/sensors/sccb.c
+++ b/esp32-s2-kaluga-1/components/sensors/sccb.c
@@ -66,7 +66,7 @@ void SCCB_Deinit(void)
     i2c_driver_delete(SCCB_I2C_PORT);
 }
 
-uint8_t SCCB_Probe()
+uint8_t SCCB_Probe(void)
 {
     uint8_t slave_addr = 0x0;
     while(slave_addr < 0x7f) {


### PR DESCRIPTION
This fixes warnings from gcc that the "function declaration isn't a prototype".