### PR TITLE
few docs translate CN->EN for the new added esp32-s2-hmi-devkit-1

### DIFF
--- a/esp32-s2-hmi-devkit-1/README_en.md
+++ b/esp32-s2-hmi-devkit-1/README_en.md
@@ -1,0 +1,69 @@
+# ESP32-S2-HMI-DevKit-1 Instructions for Use
+
+This document describes how to use the ESP32-S2-HMI-DevKit-1 development board.
+## Overview
+
+The board is an ESP32-S2-based HMI board. On-board resources are shown in the following image.
+
+![ESP32-S2-HMI-DevKit-0 Board function block diagram](docs/_static/board_func.jpg)
+
+The board uses the ESP32-S2-WROVER module, which has 4MB flash and 2MB PSRAM built in in US dollars. The board features a 4.3-inch TFT-LCD with a 16-bit 8080 and a resolution of 480×800 with a 256-stage hardware DC backlight adjustment circuit. It is equipped with a capacitive touch panel that communicates using the I2C interface.
+
+The board is equipped with inertial sensors with three-axis accelerometers and three-axis gyroscopes, ambient light sensors, temperature and humidity sensors, IO extenders, programmable RGB LED lights, dual-wire, audio amplifiers, SD card interfaces, and more.
+
+The board provides a number of extended interfaces for secondary development, including 5 V and 3.3 V power interfaces, program download/UART interfaces, I2C interfaces, SPI interfaces, USB interfaces (USB OTG support), TWAI (compatible WITH CAN 2.0) interfaces, and more.
+
+The board is equipped with a single-cell lithium-ion battery of 1950 mAh and a charging IC to charge the battery.
+
+> The engineering version of the board has the following issues that may or may not cause some functions to function properly:
+>
+>- The entire board has not been designed for low power for the time being, causing the remaining ICs and some resistors of the chip in Deep Sleep mode to still consume current (tested between 28 and 40 mA). Therefore, the battery is not connected to the motherboard when shipped by default to prevent the battery from over-letting over. This issue has been issued in the official version.
+>- The light sensor used in the engineering version causes the I2C bus to be clamped to about 1.2 V, which in turn prevents the bus from communicating properly. The device has been removed by default shipping and the issue will occur in the official version.
+>- IO46 must be low when entering download mode, but the input used by IO46 as an IO extender is high when no is running, which may prevent downloading. When the device is powered on, it is configured by default as a weak pull-up input, and the falling edge of each channel is sent to IO46 at a low level as a processing condition and remains low until the device's IO input register is read. In this way, the IO46 can be pulled down by touching the screen by touching the IC's in-in-one IO extension IO extender, thus successfully entering download mode. This issue has been issued in the official version.
+>- The infrared diode and digital LED (WS2812) do not have a switching circuit set up at this time. As a result, leDs may flash or light up during the operation of the infrared diode, and infrared diodes may also emit an outside line red during operation of the LED. This issue has been issued in the official version.
+>- When the hardware is reset, the screen content may not be updated immediately. Because the display IC of the screen comes with a memory, if the display IC does not reset at the same time as the MCU, it retains the contents of the previous memory until it is reset by the new overwritten data or hardware. This issue has been issued in the official version.
+
+## Hardware preparation
+
+- 1 x PCs with Windows, Mac OS, or Linux (Linux recommended)
+- 1 x ESP32-S2-HMI-DevKit-1
+- 1 x USB-C cable (2 USB-C cables recommended if you want to evaluate the USB function of the MCU at the same time)
+- 1 x speaker (8 Ohm, 2 W)
+- 1 x Micro-SD card (some examples may require mass storage)
+
+### Get started
+
+Before powering on, make sure that the ESP32-S2-HMI-DevKit-1 development board is intact.
+Initial settings
+
+To make it easier for you to quickly evaluate all routines, follow these steps to set up the board:
+
+1. Insert the Micro-SD card into the card slot. Make sure that your important material is backed up and that the Micro-SD may be formatted if the partition is not in FAT format.
+2. If you need to evaluate the playback audio function, connect the speaker pad near the USB port below the board to the included speakers, or to other speakers of similar size (8 Ohm, 2 W).
+
+> The engineering version of the speaker is not currently welded to the motherboard and requires you to weld it yourself.
+
+### Compilation project
+
+First, make sure that you have completed the IDF environment configuration correctly. To ensure this, enter `idf --version`in the terminal, which represents a successful installation if the output is similar to `ESP-IDF v4.2-dev-2084-g98d5b5dfd` For detailed installation and configuration instructions, refer to the [Quick Start documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/get-started/index.html).
+
+When the configuration is complete, switch to the directory where the warehouse is located. Assuming that the path of the document is `~/esp/esp-dev-kits/esp-hmi-devkits/` enter the following command at the terminal to configure the environmental variables in the engineering directory:
+```bash
+cd ~/esp/esp-dev-kits/esp-hmi-devkits
+set HMI_PATH=$(pwd)
+```
+Once the environment is configured, you can switch to the various routine folders in the examples directory and start compiling the program.
+### Engineering options
+
+You can enter the `idf.py menuconfig` sample directory.
+
+In menuconfig, make sure that the following options are configured correctly:
+
+- `(Top) > HMI Board Config > HMI board:` version selection, `ESP32-S2-HMI-DevKit-V2`
+- `(Top) > HMI Board Config > Audio HAL:` output interface selection, using PWM or DAC;
+- `(Top) > HMI Board Config > LCD Drivers:` display IC model selection, ESP32-S2-HMI-DevKit-1 IC display RM68120;
+- `(Top) > Component config > ESP32S2-specific:` go to `Support for external, SPI-connected RAM` Options:
+   - In `SPI RAM config > Set RAM clock speed:` set the clock of PSRAM to `80 MHz clock speed`;
+- `(Top) -> Component config -> FreeRTOS Tick rate (Hz):` set to `1000`.
+
+In each example, we have provided a default configuration file called `sdkconfig.defaults` and the above configuration of the options is complete.

--- a/esp32-s2-hmi-devkit-1/README_en.md
+++ b/esp32-s2-hmi-devkit-1/README_en.md
@@ -11,7 +11,7 @@ The board uses the ESP32-S2-WROVER module, which has 4MB flash and 2MB PSRAM bui
 
 The board is equipped with inertial sensors with three-axis accelerometers and three-axis gyroscopes, ambient light sensors, temperature and humidity sensors, IO extenders, programmable RGB LED lights, dual-wire, audio amplifiers, SD card interfaces and more.
 
-The board provides a number of extended interfaces for secondary development, including 5 V and 3.3 V power interfaces, program download/UART interfaces, I2C interfaces, SPI interfaces, USB interfaces (USB OTG support), TWAI (compatible WITH CAN 2.0) interfaces, and more.
+The board provides a number of extended interfaces for secondary development, including 5 V and 3.3 V power interfaces, program download/UART interfaces, I2C interfaces, SPI interfaces, USB interfaces (USB OTG support), TWAI (compatible WITH CAN 2.0) interfaces and more.
 
 The board is equipped with a single-cell lithium-ion battery of 1950 mAh and a charging IC to charge the battery.
 

--- a/esp32-s2-hmi-devkit-1/README_en.md
+++ b/esp32-s2-hmi-devkit-1/README_en.md
@@ -7,7 +7,7 @@ The board is an ESP32-S2-based HMI board. On-board resources are shown in the fo
 
 ![ESP32-S2-HMI-DevKit-0 Board function block diagram](docs/_static/board_func.jpg)
 
-The board uses the ESP32-S2-WROVER module, which has 4MB flash and 2MB PSRAM built in in US dollars. The board features a 4.3-inch TFT-LCD with a 16-bit 8080 and a resolution of 480×800 with a 256-stage hardware DC backlight adjustment circuit. It is equipped with a capacitive touch panel that communicates using the I2C interface.
+The board uses the ESP32-S2-WROVER module, which has 4MB flash and 2MB PSRAM built in. The board features a 4.3-inch TFT-LCD with a 16-bit 8080 and a resolution of 480×800 with a 256-stage hardware DC backlight adjustment circuit. It is equipped with a capacitive touch panel that communicates using the I2C interface.
 
 The board is equipped with inertial sensors with three-axis accelerometers and three-axis gyroscopes, ambient light sensors, temperature and humidity sensors, IO extenders, programmable RGB LED lights, dual-wire, audio amplifiers, SD card interfaces, and more.
 

--- a/esp32-s2-hmi-devkit-1/README_en.md
+++ b/esp32-s2-hmi-devkit-1/README_en.md
@@ -9,7 +9,7 @@ The board is an ESP32-S2-based HMI board. On-board resources are shown in the fo
 
 The board uses the ESP32-S2-WROVER module, which has 4MB flash and 2MB PSRAM built in. The board features a 4.3-inch TFT-LCD with a 16-bit 8080 and a resolution of 480×800 with a 256-stage hardware DC backlight adjustment circuit. It is equipped with a capacitive touch panel that communicates using the I2C interface.
 
-The board is equipped with inertial sensors with three-axis accelerometers and three-axis gyroscopes, ambient light sensors, temperature and humidity sensors, IO extenders, programmable RGB LED lights, dual-wire, audio amplifiers, SD card interfaces, and more.
+The board is equipped with inertial sensors with three-axis accelerometers and three-axis gyroscopes, ambient light sensors, temperature and humidity sensors, IO extenders, programmable RGB LED lights, dual-wire, audio amplifiers, SD card interfaces and more.
 
 The board provides a number of extended interfaces for secondary development, including 5 V and 3.3 V power interfaces, program download/UART interfaces, I2C interfaces, SPI interfaces, USB interfaces (USB OTG support), TWAI (compatible WITH CAN 2.0) interfaces, and more.
 

--- a/esp32-s2-hmi-devkit-1/docs/ESP32-S2-HMI-DevKit-1_Audio_en.md
+++ b/esp32-s2-hmi-devkit-1/docs/ESP32-S2-HMI-DevKit-1_Audio_en.md
@@ -37,7 +37,6 @@ The ADC of esp32-S2 is highly repetitive despite the lack of a reference and the
 We use USB to power the ESP32-S2-HMI-DevKit-1, using 13-bit resolution, attenuation of 11 dB, and range voltage of 2.6 V. After ADC1_CH8 4096 uncalibrated original values of the AD584T reference were converted to voltage via a ADC1_CH8-wheel acquisition of the 2.5 V voltage output of the AD584T reference, we obtained the following figure data:
 
 ![ADC](_static/ADC.png)
-![image](https://user-images.githubusercontent.com/16070445/110633932-ab665a80-81a9-11eb-97d3-2d640c2045f3.png)
 
 
 As you can see, under uncalibrated data, the error of the data is within ±0.005 V, and its standard deviation σ is only 3.339 LSB (0.00106 V). These errors come mainly from absolute accuracy, i.e. bias. Therefore, for ADC-sampled audio, its distortion and noise can be controlled at a high level.

--- a/esp32-s2-hmi-devkit-1/docs/ESP32-S2-HMI-DevKit-1_Audio_en.md
+++ b/esp32-s2-hmi-devkit-1/docs/ESP32-S2-HMI-DevKit-1_Audio_en.md
@@ -1,0 +1,48 @@
+# Audio
+
+ESP32-S2-HMI-DevKit-1 supports audio playback and capture. You can find examples of audio playback and acquisition in the `examples/audio/`
+
+## Audio playback
+
+ESP32-S2-HMI-DevKit-1 can be output by DAC or PWM. We recommend using PWM for audio output because the PWM output has lower noise and higher resolution (DAC output resolution is 8 bits, and PWM output can reach a resolution of up to 12 bits at a sample rate of 19.2kHz).
+
+Signals output through the IO port will first enter the digital meter for non-destructive adjustment, and then pass a 100 nF straight capacitor with a 200k resistance, with a cutoff frequency around 8 Hz. In addition, the signal is sent to a Class D audio power amplifier with a power of 3W, which sets the gain to 1.5 times through an external resistor, thereby amplifying the 3.3V output signal to 4.95 V slightly less than the PA power supply (5 V), reducing saturation distortion while minimizing the incoming sound to the sound output.
+
+The audio amplifier is powered by a 5V power domain. Before you use the playback feature, make sure that the power domain is turned on.
+
+## Audio acquisition
+
+Esp32-S2-HMI-DevKit-1 performs audio acquisition on the analog outer end through the chip's built-in ADC.
+
+The board is equipped with an analog pad with a sensitivity of -38 dB and sends the output signal to a fixed gain op amp to amplify the signal.
+
+The external amplifier is powered by a controllable 3.3 V power domain. Make sure that the power domain is turned on before using the acquisition function.
+
+>    Use timer Group to process audio acquisition, and do not use code such as the following for acquisition in tasks:
+> ```c
+>    size_t index = 0;
+>    uint16_t audio_data[configMAX_ACQUIRE_COUNT];
+>    do {
+>        audio_data[index] = adc1_get_raw(CONFIG_AUDIO_CHANNEL);
+>        ets_delay_us(1000000 / CONFIG_AUDIO_FREQ);
+>    } while (++index < CONFIG_MAX_ACQUIRE_COUNT)
+> ```
+>    Collecting using the above methods will result in the CPU being consumed and cannot be released, thereby engaging in task gate dogs (if not disabled) and making other lower-priority tasks, including IDLE Task, unable to function.
+>    When entering an ADC read acquisition into a system, you need to rewrite the functions collected by IRAM_ATTR reduce the response time of the rate and place variables in DRAM. Similarly, do not use any senum in this function.
+
+## ADC accuracy
+
+The ADC of esp32-S2 is highly repetitive despite the lack of a reference and the fact that it is powered by Buck or will result in high overall power supply noise.
+
+We use USB to power the ESP32-S2-HMI-DevKit-1, using 13-bit resolution, attenuation of 11 dB, and range voltage of 2.6 V. After ADC1_CH8 4096 uncalibrated original values of the AD584T reference were converted to voltage via a ADC1_CH8-wheel acquisition of the 2.5 V voltage output of the AD584T reference, we obtained the following figure data:
+
+![ADC](_static/ADC.png)
+![image](https://user-images.githubusercontent.com/16070445/110633932-ab665a80-81a9-11eb-97d3-2d640c2045f3.png)
+
+
+As you can see, under uncalibrated data, the error of the data is within ±0.005 V, and its standard deviation σ is only 3.339 LSB (0.00106 V). These errors come mainly from absolute accuracy, i.e. bias. Therefore, for ADC-sampled audio, its distortion and noise can be controlled at a high level.
+
+>    The 10 V voltage of the AD584T has an output noise peak of 50 uV from 0.1 to 10 Hz, 
+>    while the output noise peak of 2.5 V is obtained by an internal high-precision laser-adjusted voltage resistance, 
+>    and the transistor measured by the 10 V output provides a maximum push-pull capacity of 30 mA. 
+>    Its output noise at 2.5 V is less than the resolution of the 16-bit ADC and can be used as a test benchmark.

--- a/esp32-s2-hmi-devkit-1/docs/ESP32-S2-HMI-DevKit-1_Display_en.md
+++ b/esp32-s2-hmi-devkit-1/docs/ESP32-S2-HMI-DevKit-1_Display_en.md
@@ -1,0 +1,27 @@
+# Display and touch panel
+
+The ESP32-S2-HMI-DevKit-1 is equipped with a 4.3-inch color LCD display with a resolution of 800×480 and a touch panel with an I2C interface. The interface type and data bit width of the screen are controlled by programmable pins. The board has been communicated by means of a 16-bit 8080 side-port communication with a resistance configuration.
+
+The LCD uses a display IC of RM68120 and a touch IC of FT5436.
+
+## Communication
+
+The display IC of the LCD used in ESP32-S2-HMI-DevKit-1 has been configured to communicate using a 16-bit 8080 interface using a total of 18 GPIO interfaces, including 16-bit data cables (LCD_D0... LCD_D15), bit clock signals (LCD_WR) and data commands distinguish signals (LCD_DC/LCD_RS).
+
+Touch ICs use the I2C interface to communicate with the MCU and can be shared with other I2Cs and ICs without the need for additional GPIO interfaces. Touch IC supports the output signal after one in. First, the medium zone will be sent to the IO's P2 pin on the 20th, and the falling edge of the pin will cause the output foot of the IO extender to produce a low level, thus allowing the MCU to receive further. At this point, the source can be read by reading the input level register of the IO extender, so that the incision is from the touch IC.
+
+## Backlight
+
+The LCD has a built-in information LED that requires constant current drive using the Booster circuit. The rated current is 18 mA, at which point the current voltage is 24 V.
+
+Because PWM mentring can cause flickering, and some Bosser ICs do not support high-frequency PWM signal control, the board uses a DC modulate circuit to address these issues. The DC switch power supply inputs the VFB voltage into the op amp, where the gain resistance is a digital proton, so its resistance can be modified by the I2C bus for the purpose of modifying the gain size.
+
+The digital meter uses CAT5171 with a resolution of 256 and a maximum resistance of 50k.
+
+At the same time, Booster IC's EN foot is controlled by the IO foot's extended P7 foot and is effective at high levels. To turn off the screen while preserving the video content, you can set the pin to low to turn off screen backlighting.
+
+## Touch
+
+The board's capacitive touch panel uses a touch IC resolution of 800×480 and supports up to 5 touch and hardware gesture recognition.
+
+The display IC does not support hardware coordinate orientation conversion, so for displays that use a different rotation direction, it may be necessary for the software to exchange the data read by the touch IC or to make its resolution its own difference. Multi-touch is hardware support, and in the driver, we also provide APIs for reading multiple touch points for you to use, but the GUI library LVGL is not currently supporting multi-touch processing, and you may need to process the data for those touch points yourself at the app layer.

--- a/esp32-s2-hmi-devkit-1/docs/ESP32-S2-HMI-DevKit-1_Power_en.md
+++ b/esp32-s2-hmi-devkit-1/docs/ESP32-S2-HMI-DevKit-1_Power_en.md
@@ -1,0 +1,45 @@
+# Power
+
+For low power consumption, high power efficiency, and battery power, the ESP32-S2-HMI-DevKit-1 is designed to be divided into 5 V power domains and 3.3 V power domains, some of which can be controlled from the power supply and the other part of which is configured to be always on when the hardware is designed.
+
+The firmware burned at the factory on the board has been powered off for all controlled power domains and all ICs have been configured in low-power mode to reduce current consumption.
+## The power domain of 3.3 V
+
+The power domain is responsible for the majority of ICs and counting power supplies, but it is divided into two parts: an uncontrollable 3.3 V power domain and a controllable 3.3V power domain.
+
+The uncontrollable 3.3 V power domain cannot be switched off by the software and is obtained by the Buck circuit. In the case of a USB power input, a 5 V power supply is entered from the USB cable and, in the case of a USB disconnect, a 3.6 to 4.2 V power supply is provided to the Buck IC by a lithium battery. This power domain is responsible for powering the ESP32-S2-WROVER module, as well as other devices that can be controlled by software into low-power mode.
+
+The controllable 3.3 V power domain comes from the uncontrollable 3.3V power domain and is connected to the IO extender's P4 foot by the PMOS control switch, which is switched on at low level. This power supply is responsible for powering ICs with large static power consumption that do not enter low-power mode.
+## 5 V power domain
+
+The board's 5V power domain is responsible for powering the audio amplifier TWAI® and receiver. It comes from several sources:
+
+- USB connector
+- Externally input to the connector's 5V power port
+- The lithium battery passes through the power supply behind the Booster circuit
+
+The power supply via USB and external 5V inputs supplies power to all devices that require 5 V power (except CP2102N) and cannot be disconnected through the software. When powered by a battery, the BOSS IC's EN foot level can be controlled by extending the IO's P5 pin and 5 V is switched on at a high level.
+
+The power supply entered through the USB connector at the bottom of the board will be divided into two paths, supplying power to the CP2102N along the way and becoming a power source after passing USB_5V. Since the CP2102N only needs to be in operation when connecting to the PC, the CP2102N will only be powered on when the USB port is connected. Any 5V power input shuts down the Booster IC and charges the on-board lithium-ion battery via the charging IC.
+## Power dependency
+
+The following features depend on the 5 V power domain:
+
+- TWAI®
+- Audio amplifier
+
+The following features rely on a controlled 3.3 V power domain:
+
+- Micro-SD card
+- And the line
+- Display and touch function
+- WS2812 RGB LED
+- Infrared diodes
+
+## Power mode
+
+The power mode depends on whether the USB connector is powered and the P4, P5 pins extended by the IO interface.
+
+The P4 is a controllable 3.3 V power control pin that is switched on at a high level.
+
+The P5 is a 5 V power control pin that is turned on at a high level and can be turned off when and only when battery time is used.


### PR DESCRIPTION
# esp32-s2-hmi-devkit-1 docs translate CN->EN
README.md -> README_**en**.md
ESP32-S2-HMI-DevKit-1_Audio.md -> ESP32-S2-HMI-DevKit-1_Audio_**en**.md
ESP32-S2-HMI-DevKit-1_Display.md -> ESP32-S2-HMI-DevKit-1_Display_**en**.md
ESP32-S2-HMI-DevKit-1_Power.md -> ESP32-S2-HMI-DevKit-1_Power_**en**.md