### PR TITLE
doc: quick start guide (AEGHB-4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # esp-dev-kits
 
+## Quick start
+
+- install ESP-IDF - https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/#get-started-get-prerequisites
+- clone the repository:
+```
+git clone git@github.com:espressif/esp-dev-kits.git
+cd esp-dev-kits
+git submodule update --init --recursive
+```
+- change the directory to an example e.g.: `cd esp32-s2-hmi-devkit-1/examples/smart-panel`
+- build: `idf.py build`
+- flash and monitor: `idf.py flash monitor --port PORT`


### PR DESCRIPTION
esp-dev-kits repo is missing Quick start section. Users might to clone the repo without initializing submodules, which will result into build failure. Please, consider merging this short quick-start section so that user can get working environment quickly.