### PR TITLE
Add backlight (BL) pin to custom board (AEGHB-3)

### DIFF
--- a/esp32-s2-hmi-devkit-1/components/bsp/Kconfig.projbuild
+++ b/esp32-s2-hmi-devkit-1/components/bsp/Kconfig.projbuild
@@ -32,6 +32,10 @@ menu "HMI Board Config"
     menu "I2S LCD GPIO configuration"
         depends on LCD_INTERFACE_I2S
 
+            config LCD_BL_GPIO
+                int "LCD BL GPIO"
+                range -1 46
+                default -1
             config LCD_WR_GPIO
                 int "LCD WR GPIO"
                 range 0 46

--- a/esp32-s2-hmi-devkit-1/components/bsp/include/bsp_custom_board.h
+++ b/esp32-s2-hmi-devkit-1/components/bsp/include/bsp_custom_board.h
@@ -31,6 +31,7 @@
 #define FUNC_LCD_EN     (0)
 #define LCD_BIT_WIDTH   (16)
 
+#define GPIO_LCD_BL     (CONFIG_LCD_BL_GPIO)
 #define GPIO_LCD_CS     (GPIO_NUM_NC)
 #define GPIO_LCD_EN     (GPIO_NUM_NC)
 #define GPIO_LCD_RS     (CONFIG_LCD_RS_GPIO)


### PR DESCRIPTION
**What is the current behaviour?**
Project failed to build when `HMI_BOARD_CUSTOM` was selected in `HMI Board Config > HMI board` in menuconfig. The compiler couldn't find the GPIO_LCD_BL pin.

**What is the new behavior?** (if this is a feature change)?
Added BL pin to menuconfig. Allowed range from -1 to 46 to allow setting the pin as `GPIO_NUM_NC`.