### PR TITLE
usb_wireless_bridge: fix cannot be changed baudrate

### DIFF
--- a/esp32-s3-usb-bridge/examples/usb_wireless_bridge/main/src/app_serial.c
+++ b/esp32-s3-usb-bridge/examples/usb_wireless_bridge/main/src/app_serial.c
@@ -217,8 +217,6 @@ void serial_boot_reset(const bool dtr, const bool rts)
         gpio_set_level(GPIO_BOOT, boot);
         gpio_set_level(GPIO_RST, rst);
 
-        serial_set_baudrate(SLAVE_UART_DEFAULT_BAUD);
-
         // On ESP32, TDI jtag signal is on GPIO12, which is also a strapping pin that determines flash voltage.
         // If TDI is high when ESP32 is released from external reset, the flash voltage is set to 1.8V, and the chip will fail to boot.
         // As a solution, MTDI signal forced to be low when RST is about to go high.


### PR DESCRIPTION
Once RTS or DTR is set, the baudrate will be set to the default value, resulting in the inability to modify the baudrate.