### PR TITLE
Fix build for esp32-c3-lcdkit knob_panel example (AEGHB-1172)

### DIFF
--- a/examples/esp32-c3-lcdkit/examples/knob_panel/main/idf_component.yml
+++ b/examples/esp32-c3-lcdkit/examples/knob_panel/main/idf_component.yml
@@ -5,6 +5,7 @@ dependencies:
   espressif/esp32_c3_lcdkit: "1.0.*"
   chmorgan/esp-audio-player: "1.0.5"
   chmorgan/esp-file-iterator: "1.0.0"
+  lvgl/lvgl: "8.2"
 
   esp_codec_dev:
     public: true


### PR DESCRIPTION
Build does not work anymore because it uses a too recent version of LVGL that consumes more RAM