### PR TITLE
fix(esp32-s31-korvo): require esp_lvgl_adapter ^0.6.0 so factory_demo builds on ESP-IDF v6.1

### DIFF
--- a/examples/esp32-s31-korvo/examples/common_components/esp32_s31_korvo/idf_component.yml
+++ b/examples/esp32-s31-korvo/examples/common_components/esp32_s31_korvo/idf_component.yml
@@ -11,7 +11,7 @@ tags:
 dependencies:
   idf: ">=6.1.0"
   espressif/esp_lvgl_adapter:
-    version: "^0.5.0"
+    version: "^0.6.0"
     public: true
   button:
     version: "^4"


### PR DESCRIPTION
## Problem

`examples/esp32-s31-korvo/examples/factory_demo` does not build against a released ESP-IDF v6.1.

The Korvo BSP (`common_components/esp32_s31_korvo/idf_component.yml`) pins:

```yaml
espressif/esp_lvgl_adapter:
  version: "^0.5.0"
```

which resolves to **0.5.3**. That release still includes `esp_async_fbcpy.h`. ESP-IDF renamed that API to `esp_async_color_convert` — now provided by `esp_driver_dma` — before v6.1.0 was released, so the build fails:

```
managed_components/espressif__esp_lvgl_adapter/src/display/bridge/common/display_bridge_common.h:39:10:
fatal error: esp_async_fbcpy.h: No such file or directory
   39 | #include "esp_async_fbcpy.h"
```

Four translation units fail this way (`esp_lv_adapter.c`, `lvgl_bridge_v9.c`, `lvgl_ppa_accel_v9.c`, `display_manager.c`).

The example's own README documents the standard flow, which is what hits this:

```bash
idf.py --preview set-target esp32s31
idf.py build
```

The committed firmware was built against `v6.1-dev-4659-g3e8969ded88`, a dev commit predating the rename — so this only shows up for anyone building from a released v6.1.

## Fix

Bump the constraint to `^0.6.0`. The 0.6.x line tracks the renamed API.

## Verification

Reproduced and fixed on hardware — ESP32-S31-Korvo-1 V1.1 with the 4.3" LCD sub-board and OV3660:

- ESP-IDF `release/v6.1` (reports `v6.1.0`), macOS arm64, `riscv32-esp-elf-gcc 15.2.0`
- Before: build fails as above.
- After: `idf.py build` succeeds — `esp32_s31_korvo_factory_demo.bin` 0x18f8e0 bytes.
- Flashed and booted on the board; LCD, GT1151 touch, OV3660 preview, WS2812, the four ADC buttons and the ES8389 codec all initialise normally.

Resolved dependency goes `esp_lvgl_adapter 0.5.3` → `0.6.2`, with `lvgl 9.5.0` unchanged.